### PR TITLE
Configure pytest settings for test discovery and default CLI flags

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -25,7 +25,7 @@ docker exec travel-stream-backend pip install -r requirements-dev.txt
 ### Run tests
 
 ```bash
-docker exec travel-stream-backend pytest --color=yes
+docker exec travel-stream-backend pytest
 ```
 
 ### Run linter

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = travel_stream.settings
+python_files = tests.py test.py test_*.py *_test.py
+python_classes = Test*
+python_functions = test_*
+addopts = -v --color=yes


### PR DESCRIPTION
- Add verbose flag `-v` and color flag `--color=yes` as default CLI flags.
- Add Django default `tests.py` files for pytest test discovery.