### PR TITLE
Add support for PostgreSQL to backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,6 +5,12 @@ ENV PYTHONPATH=/app
 ENV DJANGO_SETTINGS_MODULE=travel_stream.settings
 WORKDIR /app
 COPY . .
+
+# Add build dependencies for psycopg
+RUN apk update && apk add --no-cache \
+    build-base \
+    postgresql-dev \
+    && rm -rf /var/cache/apk/*
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 EXPOSE 8000

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,17 +7,14 @@ The backend is built with Python 3.13 and Django ~5.1.
 Follow the steps below to set up a development environment. This guide was tested using macOS Sequoia 15.3 on Apple Silicon with `zsh` and Docker Desktop.
 
 ```bash
-# Make sure you are in the backend directory, the same one this file is in.
-cd backend
+# Make sure you are in the parent directory.
+cd ../
 
-# Build the image
-docker build -t travel-stream-backend .
-
-# Run the container
-docker run -d -p 8000:8000 -v $(pwd):/app --name travel-stream-backend travel-stream-backend
+# Build the image and run the container
+docker compose up backend
 
 # Install development dependencies
-docker exec travel-stream-backend pip install -r requirements-dev.txt
+docker compose exec backend pip install -r requirements-dev.txt
 ```
 
 ## Usage
@@ -25,17 +22,17 @@ docker exec travel-stream-backend pip install -r requirements-dev.txt
 ### Run tests
 
 ```bash
-docker exec travel-stream-backend pytest
+docker compose exec backend pytest
 ```
 
 ### Run linter
 
 ```bash
-docker exec travel-stream-backend flake8
+docker compose exec backend flake8
 ```
 
 ### Run formatter
 
 ```bash
-docker exec travel-stream-backend black .
+docker compose exec backend black .
 ```

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 Django~=5.1
 django-environ~=0.12  # supports Python 3.13
+psycopg~=3.2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,23 @@
+services:
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: travel_stream
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  backend:
+    build: ./backend
+    volumes:
+      - ./backend:/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
- Add `docker-compose.yaml` to run backend and PostgreSQL services.
- Update backend `README.md` usage instructions for docker compose.
- Add `psycopg` Python adapter for PostgreSQL to `requirements.txt`. Fun fact: the name "psycopg" came from mistyping the word "psycho" as in "psychotic," which was how the existing PostgreSQL adapters felt for the creator of `psycopg` at the time. [Source](https://stackoverflow.com/a/61046017).
- Add build tools (like `make` and `gcc`) to Docker image for compiling things like PostgreSQL extensions with `psycopg`.