### PR TITLE
Configure `flake8` max line length to match `black`'s default line length

### DIFF
--- a/backend/.flake8
+++ b/backend/.flake8
@@ -1,2 +1,4 @@
 [flake8]
 exclude = */migrations/*
+# 88 characters is the default max line length for black
+max-line-length = 88


### PR DESCRIPTION
- The linter and formatter must agree on an acceptable max line length in order for all checks to pass.