### PR TITLE
Add Django configuration for CORS

### DIFF
--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -12,6 +12,7 @@ SECRET_KEY=secret
 
 # A list of all the people who get code error notifications.
 ADMINS="John Doe <john@example.com>, Mary <mary@example.com>"
+ALLOWED_HOSTS=127.0.0.1,localhost,backend
 
 # A list of all the people who should get broken link notifications.
 MANAGERS="Blake <blake@cyb.org>, Alice Judge <alice@cyb.org>"

--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -15,6 +15,7 @@ ADMINS="John Doe <john@example.com>, Mary <mary@example.com>"
 
 # A list of all the people who should get broken link notifications.
 MANAGERS="Blake <blake@cyb.org>, Alice Judge <alice@cyb.org>"
+CORS_ALLOWED_ORIGINS=http://127.0.0.1:5173
 
 # By default, Django will send system email from root@localhost.
 # However, some mail providers reject all email from this address.

--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -18,6 +18,9 @@ ALLOWED_HOSTS=127.0.0.1,localhost,backend
 MANAGERS="Blake <blake@cyb.org>, Alice Judge <alice@cyb.org>"
 CORS_ALLOWED_ORIGINS=http://127.0.0.1:5173
 
+# A list of all the people who get code error notifications.
+ADMINS="John Doe,john@example.com;Mary,mary@example.com"
+
 # By default, Django will send system email from root@localhost.
 # However, some mail providers reject all email from this address.
 SERVER_EMAIL=webmaster@example.com

--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -1,21 +1,14 @@
 # PostgreSQL database connection string
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/travel_stream
 
-# SECURITY WARNING: don't run with the debug turned on in production!
+# SECURITY WARNING: don't run with debug mode turned on in production!
 DEBUG=True
-
-# Should robots.txt allow everything to be crawled?
-ALLOW_ROBOTS=False
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY=secret
 
-# A list of all the people who get code error notifications.
-ADMINS="John Doe <john@example.com>, Mary <mary@example.com>"
 ALLOWED_HOSTS=127.0.0.1,localhost,backend
 
-# A list of all the people who should get broken link notifications.
-MANAGERS="Blake <blake@cyb.org>, Alice Judge <alice@cyb.org>"
 CORS_ALLOWED_ORIGINS=http://127.0.0.1:5173
 
 # A list of all the people who get code error notifications.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 Django~=5.1
+django-cors-headers~=4.7  # supports Django 5.2
 django-environ~=0.12  # supports Python 3.13
 psycopg~=3.2

--- a/backend/travel_stream/settings.py
+++ b/backend/travel_stream/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 import os
 import environ
 from pathlib import Path
+from .utils import parse_comma_separated_str, parse_name_email_pair_str
 
 env = environ.Env(
     # set casting, default value
@@ -34,7 +35,7 @@ SECRET_KEY = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG")
 
-ALLOWED_HOSTS = env("ALLOWED_HOSTS", cast=lambda v: [s.strip() for s in v.split(",")])
+ALLOWED_HOSTS = env("ALLOWED_HOSTS", cast=parse_comma_separated_str)
 
 
 # Application definition
@@ -138,13 +139,10 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 AUTH_USER_MODEL = "users.User"
 
-CORS_ALLOWED_ORIGINS = env("CORS_ALLOWED_ORIGINS", cast=lambda v: [s.strip() for s in v.split(",")])
+CORS_ALLOWED_ORIGINS = env("CORS_ALLOWED_ORIGINS", cast=parse_comma_separated_str)
 
 CORS_ALLOW_CREDENTIALS = True
 
-# Each item in the list should be a tuple of (Full name, email address).
-# Example:
-# [("John", "john@example.com"), ("Mary", "mary@example.com")]
-ADMINS = env("ADMINS", cast=lambda v: [tuple(s.split(",")) for s in v.split(";")])
+ADMINS = env("ADMINS", cast=parse_name_email_pair_str)
 
 SERVER_EMAIL = env("SERVER_EMAIL")

--- a/backend/travel_stream/settings.py
+++ b/backend/travel_stream/settings.py
@@ -47,12 +47,15 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    # third party apps
+    "corsheaders",
     # custom apps
     "apps.core",
     "apps.users",
 ]
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -134,3 +137,7 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 AUTH_USER_MODEL = "users.User"
+
+CORS_ALLOWED_ORIGINS = env("CORS_ALLOWED_ORIGINS", cast=lambda v: [s.strip() for s in v.split(",")])
+
+CORS_ALLOW_CREDENTIALS = True

--- a/backend/travel_stream/settings.py
+++ b/backend/travel_stream/settings.py
@@ -139,7 +139,9 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 AUTH_USER_MODEL = "users.User"
 
-CORS_ALLOWED_ORIGINS = env("CORS_ALLOWED_ORIGINS", cast=parse_comma_separated_str, default=[])
+CORS_ALLOWED_ORIGINS = env(
+    "CORS_ALLOWED_ORIGINS", cast=parse_comma_separated_str, default=[]
+)
 
 CORS_ALLOW_CREDENTIALS = True
 

--- a/backend/travel_stream/settings.py
+++ b/backend/travel_stream/settings.py
@@ -35,7 +35,7 @@ SECRET_KEY = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG")
 
-ALLOWED_HOSTS = env("ALLOWED_HOSTS", cast=parse_comma_separated_str)
+ALLOWED_HOSTS = env("ALLOWED_HOSTS", cast=parse_comma_separated_str, default=[])
 
 
 # Application definition

--- a/backend/travel_stream/settings.py
+++ b/backend/travel_stream/settings.py
@@ -141,3 +141,10 @@ AUTH_USER_MODEL = "users.User"
 CORS_ALLOWED_ORIGINS = env("CORS_ALLOWED_ORIGINS", cast=lambda v: [s.strip() for s in v.split(",")])
 
 CORS_ALLOW_CREDENTIALS = True
+
+# Each item in the list should be a tuple of (Full name, email address).
+# Example:
+# [("John", "john@example.com"), ("Mary", "mary@example.com")]
+ADMINS = env("ADMINS", cast=lambda v: [tuple(s.split(",")) for s in v.split(";")])
+
+SERVER_EMAIL = env("SERVER_EMAIL")

--- a/backend/travel_stream/settings.py
+++ b/backend/travel_stream/settings.py
@@ -34,7 +34,7 @@ SECRET_KEY = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG")
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = env("ALLOWED_HOSTS", cast=lambda v: [s.strip() for s in v.split(",")])
 
 
 # Application definition

--- a/backend/travel_stream/settings.py
+++ b/backend/travel_stream/settings.py
@@ -145,4 +145,4 @@ CORS_ALLOW_CREDENTIALS = True
 
 ADMINS = env("ADMINS", cast=parse_name_email_pair_str, default=[])
 
-SERVER_EMAIL = env("SERVER_EMAIL")
+SERVER_EMAIL = env("SERVER_EMAIL", default="root@localhost")

--- a/backend/travel_stream/settings.py
+++ b/backend/travel_stream/settings.py
@@ -139,10 +139,10 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 AUTH_USER_MODEL = "users.User"
 
-CORS_ALLOWED_ORIGINS = env("CORS_ALLOWED_ORIGINS", cast=parse_comma_separated_str)
+CORS_ALLOWED_ORIGINS = env("CORS_ALLOWED_ORIGINS", cast=parse_comma_separated_str, default=[])
 
 CORS_ALLOW_CREDENTIALS = True
 
-ADMINS = env("ADMINS", cast=parse_name_email_pair_str)
+ADMINS = env("ADMINS", cast=parse_name_email_pair_str, default=[])
 
 SERVER_EMAIL = env("SERVER_EMAIL")

--- a/backend/travel_stream/tests/test_utils.py
+++ b/backend/travel_stream/tests/test_utils.py
@@ -68,14 +68,18 @@ def test_parse_name_email_pair_str_valid(
         # Too many parts in one pair
         (
             "John Doe,john@example.com,extra;Jane Doe,jane@example.com",
-            ("Invalid name-email pair 'John Doe,john@example.com,extra'. "
-             "Each pair must have exactly two parts"),
+            (
+                "Invalid name-email pair 'John Doe,john@example.com,extra'. "
+                "Each pair must have exactly two parts"
+            ),
         ),
         # Empty parts
         (
             "John Doe,;Jane Doe,jane@example.com",
-            ("Invalid name-email pair 'John Doe,'. "
-             "Each pair must have exactly two parts"),
+            (
+                "Invalid name-email pair 'John Doe,'. "
+                "Each pair must have exactly two parts"
+            ),
         ),
         # Just commas
         (

--- a/backend/travel_stream/tests/test_utils.py
+++ b/backend/travel_stream/tests/test_utils.py
@@ -1,0 +1,98 @@
+import pytest
+from travel_stream.utils import parse_comma_separated_str, parse_name_email_pair_str
+
+
+@pytest.mark.parametrize(
+    "input_str,expected",
+    [
+        ("", []),
+        (",", []),
+        (",,", []),
+        ("localhost", ["localhost"]),
+        ("localhost,example.com", ["localhost", "example.com"]),
+        ("localhost, example.com", ["localhost", "example.com"]),
+        ("  localhost  ,  example.com  ", ["localhost", "example.com"]),
+        (",example.com", ["example.com"]),
+        ("example.com,", ["example.com"]),
+        (",,example.com,,test.com,,", ["example.com", "test.com"]),
+        ("  ,  ,  example.com  ,  ,  ", ["example.com"]),
+    ],
+)
+def test_parse_comma_separated_str(input_str: str, expected: list[str]) -> None:
+    """Test the parse_comma_separated_str function with various inputs."""
+    assert parse_comma_separated_str(input_str) == expected
+
+
+@pytest.mark.parametrize(
+    "input_str,expected",
+    [
+        # Valid inputs
+        (
+            "John Doe,john@example.com;Jane Doe,jane@example.com",
+            [("John Doe", "john@example.com"), ("Jane Doe", "jane@example.com")],
+        ),
+        # Single pair
+        (
+            "John Doe,john@example.com",
+            [("John Doe", "john@example.com")],
+        ),
+        # Extra whitespace
+        (
+            "  John Doe  ,  john@example.com  ;  Jane Doe  ,  jane@example.com  ",
+            [("John Doe", "john@example.com"), ("Jane Doe", "jane@example.com")],
+        ),
+        ("", []),
+        ("   ", []),
+        # Empty sections should be ignored
+        (
+            "John Doe,john@example.com;;;Jane Doe,jane@example.com",
+            [("John Doe", "john@example.com"), ("Jane Doe", "jane@example.com")],
+        ),
+    ],
+)
+def test_parse_name_email_pair_str_valid(
+    input_str: str, expected: list[tuple[str, str]]
+) -> None:
+    """Test parse_name_email_pair_str function with valid inputs."""
+    assert parse_name_email_pair_str(input_str) == expected
+
+
+@pytest.mark.parametrize(
+    "input_str,error_message",
+    [
+        # Missing email
+        (
+            "John Doe",
+            "Invalid name-email pair 'John Doe'. Each pair must have exactly two parts",
+        ),
+        # Too many parts in one pair
+        (
+            "John Doe,john@example.com,extra;Jane Doe,jane@example.com",
+            "Invalid name-email pair 'John Doe,john@example.com,extra'. \
+                Each pair must have exactly two parts",
+        ),
+        # Empty parts
+        (
+            "John Doe,;Jane Doe,jane@example.com",
+            "Invalid name-email pair 'John Doe,'. \
+                Each pair must have exactly two parts",
+        ),
+        # Just commas
+        (
+            ",,,",
+            "Invalid name-email pair ',,,'. Each pair must have exactly two parts",
+        ),
+        # Just semicolons - this is actually valid - all empty pairs are filtered out
+        (
+            ";;;",
+            [],
+        ),
+    ],
+)
+def test_parse_name_email_pair_str_invalid(input_str: str, error_message: str) -> None:
+    """Test parse_name_email_pair_str function with invalid inputs."""
+    if error_message == []:  # Special case for valid but empty result
+        assert parse_name_email_pair_str(input_str) == []
+    else:
+        with pytest.raises(ValueError, match=error_message):
+            parse_name_email_pair_str(input_str)

--- a/backend/travel_stream/tests/test_utils.py
+++ b/backend/travel_stream/tests/test_utils.py
@@ -68,14 +68,14 @@ def test_parse_name_email_pair_str_valid(
         # Too many parts in one pair
         (
             "John Doe,john@example.com,extra;Jane Doe,jane@example.com",
-            "Invalid name-email pair 'John Doe,john@example.com,extra'. \
-                Each pair must have exactly two parts",
+            ("Invalid name-email pair 'John Doe,john@example.com,extra'. "
+             "Each pair must have exactly two parts"),
         ),
         # Empty parts
         (
             "John Doe,;Jane Doe,jane@example.com",
-            "Invalid name-email pair 'John Doe,'. \
-                Each pair must have exactly two parts",
+            ("Invalid name-email pair 'John Doe,'. "
+             "Each pair must have exactly two parts"),
         ),
         # Just commas
         (

--- a/backend/travel_stream/utils.py
+++ b/backend/travel_stream/utils.py
@@ -1,0 +1,59 @@
+def parse_comma_separated_str(value: str) -> list[str]:
+    """
+    Parse a comma-separated string into a list of strings,
+    stripping whitespace and filtering empty values.
+
+    Args:
+        value: A string containing comma-separated values
+
+    Returns:
+        A list of non-empty strings with whitespace stripped
+
+    Example:
+        >>> parse_comma_separated_str("localhost, example.com, test.com")
+        ['localhost', 'example.com', 'test.com']
+        >>> parse_comma_separated_str(",example.com,,test.com,")
+        ['example.com', 'test.com']
+    """
+    return [s.strip() for s in value.split(",") if s.strip()]
+
+
+def parse_name_email_pair_str(value: str) -> list[tuple[str, str]]:
+    """
+    Parse a semicolon-separated string of comma-separated name-email pairs
+    into a list of tuples.
+    Each pair should be in the format "name,email@example.com" with pairs
+    separated by semicolons.
+
+    Args:
+        value: A string containing semicolon-separated name-email pairs
+
+    Returns:
+        A list of tuples, each containing (name, email)
+
+    Raises:
+        ValueError: If any pair doesn't contain exactly two parts (name and email)
+                  or if the string is malformed
+
+    Example:
+        >>> parse_name_email_pair_str(
+            "John Doe,john@example.com;Jane Doe,jane@example.com"
+        )
+        [('John Doe', 'john@example.com'), ('Jane Doe', 'jane@example.com')]
+    """
+    if not value.strip():
+        return []
+
+    result = []
+    pairs = [p.strip() for p in value.split(";") if p.strip()]
+
+    for pair in pairs:
+        parts = [p.strip() for p in pair.split(",") if p.strip()]
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid name-email pair '{pair}'. Each pair must have exactly two "
+                "parts: name and email separated by a comma"
+            )
+        result.append(tuple(parts))
+
+    return result


### PR DESCRIPTION
- Add `CORS_ALLOWED_ORIGINS` setting which is configured using an environment variable.
- Enable `ALLOWED_HOSTS`, `ADMINS`, and `SERVER_EMAIL` to be configured using environment variables.
- Remove unused and unneeded `ALLOW_ROBOTS` and `MANAGERS` variables from environment variable template.
- Add utility functions with tests for parsing comma-separated strings and strings with name-email pairs.