### PR TITLE
Configure Django CSRF protection and session cookies

### DIFF
--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -11,6 +11,8 @@ ALLOWED_HOSTS=127.0.0.1,localhost,backend
 
 CORS_ALLOWED_ORIGINS=http://127.0.0.1:5173
 
+CSRF_TRUSTED_ORIGINS=http://127.0.0.1:5173
+
 # A list of all the people who get code error notifications.
 ADMINS="John Doe,john@example.com;Mary,mary@example.com"
 

--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -13,8 +13,6 @@ CORS_ALLOWED_ORIGINS=http://127.0.0.1:5173
 
 CSRF_TRUSTED_ORIGINS=http://127.0.0.1:5173
 
-SESSION_COOKIE_SECURE=False
-
 # A list of all the people who get code error notifications.
 ADMINS="John Doe,john@example.com;Mary,mary@example.com"
 

--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -13,6 +13,8 @@ CORS_ALLOWED_ORIGINS=http://127.0.0.1:5173
 
 CSRF_TRUSTED_ORIGINS=http://127.0.0.1:5173
 
+SESSION_COOKIE_SECURE=False
+
 # A list of all the people who get code error notifications.
 ADMINS="John Doe,john@example.com;Mary,mary@example.com"
 

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -1,3 +1,12 @@
 from django.shortcuts import render  # noqa: F401
+from django.http import JsonResponse
+from django.views.decorators.http import require_POST, require_safe
+from django.middleware.csrf import get_token
 
-# Create your views here.
+@require_safe
+def get_csrf_token(request):
+    return JsonResponse({"csrf_token": get_token(request)})
+
+@require_POST
+def test_post(request):
+    return JsonResponse({"message": "Hello, world!"})

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -3,9 +3,11 @@ from django.http import JsonResponse
 from django.views.decorators.http import require_POST, require_safe
 from django.middleware.csrf import get_token
 
+
 @require_safe
 def get_csrf_token(request):
     return JsonResponse({"csrf_token": get_token(request)})
+
 
 @require_POST
 def test_post(request):

--- a/backend/travel_stream/settings.py
+++ b/backend/travel_stream/settings.py
@@ -149,10 +149,10 @@ CSRF_TRUSTED_ORIGINS = env(
     "CSRF_TRUSTED_ORIGINS", cast=parse_comma_separated_str, default=[]
 )
 
-SESSION_ENGINE = 'django.contrib.sessions.backends.db'
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
 SESSION_COOKIE_SECURE = True  # requires HTTPS except on localhost
 SESSION_COOKIE_HTTPONLY = True
-SESSION_COOKIE_SAMESITE = 'Lax'
+SESSION_COOKIE_SAMESITE = "Lax"
 SESSION_COOKIE_AGE = 43200  # 12 hours in seconds
 
 ADMINS = env("ADMINS", cast=parse_name_email_pair_str, default=[])

--- a/backend/travel_stream/settings.py
+++ b/backend/travel_stream/settings.py
@@ -150,7 +150,7 @@ CSRF_TRUSTED_ORIGINS = env(
 )
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'
-SESSION_COOKIE_SECURE = env("SESSION_COOKIE_SECURE", cast=bool, default=True)
+SESSION_COOKIE_SECURE = True  # requires HTTPS except on localhost
 SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SAMESITE = 'Lax'
 SESSION_COOKIE_AGE = 43200  # 12 hours in seconds

--- a/backend/travel_stream/settings.py
+++ b/backend/travel_stream/settings.py
@@ -149,6 +149,12 @@ CSRF_TRUSTED_ORIGINS = env(
     "CSRF_TRUSTED_ORIGINS", cast=parse_comma_separated_str, default=[]
 )
 
+SESSION_ENGINE = 'django.contrib.sessions.backends.db'
+SESSION_COOKIE_SECURE = env("SESSION_COOKIE_SECURE", cast=bool, default=True)
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = 'Lax'
+SESSION_COOKIE_AGE = 43200  # 12 hours in seconds
+
 ADMINS = env("ADMINS", cast=parse_name_email_pair_str, default=[])
 
 SERVER_EMAIL = env("SERVER_EMAIL", default="root@localhost")

--- a/backend/travel_stream/settings.py
+++ b/backend/travel_stream/settings.py
@@ -142,8 +142,12 @@ AUTH_USER_MODEL = "users.User"
 CORS_ALLOWED_ORIGINS = env(
     "CORS_ALLOWED_ORIGINS", cast=parse_comma_separated_str, default=[]
 )
-
 CORS_ALLOW_CREDENTIALS = True
+
+CSRF_USE_SESSIONS = True  # Store CSRF token in the session instead of in a cookie
+CSRF_TRUSTED_ORIGINS = env(
+    "CSRF_TRUSTED_ORIGINS", cast=parse_comma_separated_str, default=[]
+)
 
 ADMINS = env("ADMINS", cast=parse_name_email_pair_str, default=[])
 

--- a/backend/travel_stream/urls.py
+++ b/backend/travel_stream/urls.py
@@ -18,12 +18,15 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 from django.http import JsonResponse
+from apps.core.views import test_post, get_csrf_token
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("csrf/", get_csrf_token, name="get_csrf_token"),
     path(
         "health_check/",
         lambda request: JsonResponse({"status": "ok"}),
         name="health_check",
     ),
+    path("test_post/", test_post, name="test_post"),
 ]


### PR DESCRIPTION
- Add `csrf/` route to backend for getting a CSRF token (stored in session in database, not in cookies).
- Add `test_post/` route to backend for testing a POST request with CSRF protection.
- Session cookie `Secure` flag is always set to `True` since `localhost` is exempt from HTTPS requirement with `Secure` flag.
- Session cookie `Samesite` is always set to 'Lax' since backend and frontend are considered different sites.