### PR TITLE
Remove unnecessary starting slash in Django URLs and prevent warnings

### DIFF
--- a/backend/travel_stream/urls.py
+++ b/backend/travel_stream/urls.py
@@ -24,8 +24,8 @@ from apps.users.views import login_view, logout_view
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("csrf/", get_csrf_token, name="get_csrf_token"),
-    path("/users/login/", login_view, name="login"),
-    path("/users/logout/", logout_view, name="logout"),
+    path("users/login/", login_view, name="login"),
+    path("users/logout/", logout_view, name="logout"),
     path(
         "health_check/",
         lambda request: JsonResponse({"status": "ok"}),


### PR DESCRIPTION
```
backend-1   | WARNINGS:
backend-1   | ?: (urls.W002) Your URL pattern '/users/login/' [name='login'] has a route beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
backend-1   | ?: (urls.W002) Your URL pattern '/users/logout/' [name='logout'] has a route beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
```