### PR TITLE
Enable Firebase users to authenticate with backend API

### DIFF
--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -1,7 +1,23 @@
 from django.contrib.auth import authenticate, logout
 from django.shortcuts import render  # noqa: F401
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_POST, require_safe
 from django.http import HttpRequest, JsonResponse
+
+
+@require_safe
+def session_view(request: HttpRequest) -> JsonResponse:
+    """
+    Handle the request to check if a valid session exists.
+
+    Args:
+        request:
+               The HTTP request object.
+    Returns:
+        JsonResponse:
+            A JSON response indicating whether the user is authenticated.
+    """
+    status = 200 if request.user.is_authenticated else 401
+    return JsonResponse({}, status=status)
 
 
 @require_POST

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import authenticate, logout
 from django.shortcuts import render  # noqa: F401
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST, require_safe
 from django.http import HttpRequest, JsonResponse
 
@@ -20,6 +21,7 @@ def session_view(request: HttpRequest) -> JsonResponse:
     return JsonResponse({}, status=status)
 
 
+@csrf_exempt
 @require_POST
 def login_view(request: HttpRequest) -> JsonResponse:
     """

--- a/backend/travel_stream/urls.py
+++ b/backend/travel_stream/urls.py
@@ -24,7 +24,7 @@ from apps.users.views import login_view, logout_view, session_view
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("csrf/", get_csrf_token, name="get_csrf_token"),
-    path("users/session", session_view, name="session"),
+    path("users/session/", session_view, name="session"),
     path("users/login/", login_view, name="login"),
     path("users/logout/", logout_view, name="logout"),
     path(

--- a/backend/travel_stream/urls.py
+++ b/backend/travel_stream/urls.py
@@ -19,11 +19,12 @@ from django.contrib import admin
 from django.urls import path
 from django.http import JsonResponse
 from apps.core.views import test_post, get_csrf_token
-from apps.users.views import login_view, logout_view
+from apps.users.views import login_view, logout_view, session_view
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("csrf/", get_csrf_token, name="get_csrf_token"),
+    path("users/session", session_view, name="session"),
     path("users/login/", login_view, name="login"),
     path("users/logout/", logout_view, name="logout"),
     path(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,10 +3,14 @@
 import "./App.css";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "@user/utils/firebase";
-import { AuthDisplay } from "@user/components/AuthDisplay.tsx";
+import { AuthDisplay } from "@user/components/AuthDisplay";
+import { useBackendAuth } from "@user/hooks/useBackendAuth";
 
 export function App() {
-  const [user, loading, error] = useAuthState(auth);
+  const { handleFirebaseUserChange } = useBackendAuth();
+  const [user, loading, error] = useAuthState(auth, {
+    onUserChanged: handleFirebaseUserChange,
+  });
 
   return (
     <>

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,0 +1,6 @@
+// constants.ts
+
+export const API_BASE_URL =
+  process.env.NODE_ENV === "production"
+    ? "https://api.travelstreamapp.com"
+    : "http://127.0.0.1:8000";

--- a/frontend/src/user/hooks/useBackendAuth.ts
+++ b/frontend/src/user/hooks/useBackendAuth.ts
@@ -1,0 +1,83 @@
+// user/hooks/useBackendAuth.ts
+
+import { useCallback, useState } from "react";
+import { User } from "firebase/auth";
+import { API_BASE_URL } from "../../constants";
+
+export function useBackendAuth() {
+  const [backendLoadingStatus, setBackendLoadingStatus] =
+    useState<boolean>(false);
+  const [backendLoginError, setBackendLoginError] = useState<Error | null>(
+    null,
+  );
+  const [isBackendLoggedIn, setIsBackendLoggedIn] = useState<boolean>(false);
+
+  const handleFirebaseUserChange = async (firebaseUser: User | null) => {
+    if (firebaseUser) {
+      await checkBackendSession();
+    }
+
+    if (firebaseUser && !isBackendLoggedIn) {
+      await loginToBackend(firebaseUser);
+    }
+
+    if (!firebaseUser) {
+      await logoutFromBackend();
+    }
+  };
+
+  const checkBackendSession = useCallback(async () => {
+    setBackendLoadingStatus(true);
+    try {
+      const response = await fetch(`${API_BASE_URL}/users/session/`);
+      setIsBackendLoggedIn(response.ok);
+    } catch (error) {
+      console.error("Error checking backend session: ", error);
+      setIsBackendLoggedIn(false);
+    } finally {
+      setBackendLoadingStatus(false);
+    }
+  }, []);
+
+  const loginToBackend = useCallback(async (firebaseUser: User) => {
+    setBackendLoginError(null);
+    try {
+      const response = await fetch(`${API_BASE_URL}/users/login/`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await firebaseUser.getIdToken()}`,
+        },
+      });
+      setIsBackendLoggedIn(response.ok);
+      if (!response.ok) {
+        setBackendLoginError(new Error("Backend authentication failed"));
+      }
+    } catch (error) {
+      console.error("Error logging in to backend: ", error);
+      setBackendLoginError(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
+  }, []);
+
+  const logoutFromBackend = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/users/logout/`, {
+        method: "POST",
+      });
+      if (response.ok) {
+        setIsBackendLoggedIn(false);
+      } else {
+        console.error("Error logging out from backend: ", response.statusText);
+      }
+    } catch (error) {
+      console.error("Error logging out from backend: ", error);
+    }
+  }, []);
+
+  return {
+    backendLoadingStatus,
+    backendLoginError,
+    handleFirebaseUserChange,
+  };
+}


### PR DESCRIPTION
This pull request introduces a new authentication flow that integrates Firebase authentication with backend session management. The most important changes include adding a new session view in the backend, updating the frontend to use a new custom hook for backend authentication, and defining a constant for the API base URL.

Backend changes:

* [`backend/apps/users/views.py`](diffhunk://#diff-16c9097f8e004715a8da7c811a72794ae4c6346e4c446a8d63463f5d010c778aL3-R24): Added a new `session_view` function to handle session validation and updated the `login_view` to be exempt from CSRF protection.
* [`backend/travel_stream/urls.py`](diffhunk://#diff-f10e4616e47fae7f5821bbcb2e3ea64c3e516c4743b649eb2288c3a6b8ac6a69L22-R27): Added a new URL pattern for the session view.

Frontend changes:

* [`frontend/src/App.tsx`](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL6-R13): Updated to use the new `useBackendAuth` hook, which handles changes in Firebase user state and synchronizes with the backend session.
* [`frontend/src/constants.ts`](diffhunk://#diff-960508675c48f0ea375f7edf25c366b38b88b9810d17c6ecaac6d338d9bbd13aR1-R6): Added a new constant `API_BASE_URL` to manage different base URLs for production and development environments.
* [`frontend/src/user/hooks/useBackendAuth.ts`](diffhunk://#diff-ad449176bef66c0d49d127aa6fad3c2e3f01be5af7ecf15e4ab966d55de5ba96R1-R83): Created a new custom hook to manage backend authentication, including checking session status, logging in, and logging out.