### PR TITLE
Remove coverage thresholds and update job names for CI to be consistent

### DIFF
--- a/.github/workflows/check-javascript-coverage.yaml
+++ b/.github/workflows/check-javascript-coverage.yaml
@@ -12,7 +12,7 @@ on:
       - "frontend/**/*.json"
       - ".github/workflows/check-javascript-coverage.yaml"
 jobs:
-  vitest:
+  check-coverage:
     runs-on: ubuntu-latest
     container: node:22-alpine
     steps:

--- a/.github/workflows/check-javascript-format.yaml
+++ b/.github/workflows/check-javascript-format.yaml
@@ -12,7 +12,7 @@ on:
       - "frontend/**/*.json"
       - ".github/workflows/check-javascript-format.yaml"
 jobs:
-  prettier:
+  check-format:
     runs-on: ubuntu-latest
     container: node:22-alpine
     steps:

--- a/.github/workflows/check-javascript-lint.yaml
+++ b/.github/workflows/check-javascript-lint.yaml
@@ -12,7 +12,7 @@ on:
       - "frontend/**/*.json"
       - ".github/workflows/check-javascript-lint.yaml"
 jobs:
-  eslint:
+  check-lint:
     runs-on: ubuntu-latest
     container: node:22-alpine
     steps:

--- a/.github/workflows/check-javascript-tests.yaml
+++ b/.github/workflows/check-javascript-tests.yaml
@@ -12,7 +12,7 @@ on:
       - "frontend/**/*.json"
       - ".github/workflows/check-javascript-tests.yaml"
 jobs:
-  vitest:
+  check-tests:
     runs-on: ubuntu-latest
     container: node:22-alpine
     steps:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,12 +18,6 @@ export default defineConfig({
     environment: "jsdom",
     coverage: {
       provider: "istanbul",
-      thresholds: {
-        lines: 80,
-        functions: 80,
-        branches: 80,
-        statements: 80,
-      },
     },
   },
 });


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflows and a modification to the `vite.config.ts` file. The most important changes include renaming job names in multiple workflow files and removing coverage thresholds in the Vite configuration.

Changes to GitHub Actions workflows:

* [`.github/workflows/check-javascript-coverage.yaml`](diffhunk://#diff-0642419749f3de2f2f829928a3f2e1e87872b2a624c72f887b86e9e869b59482L15-R15): Renamed job from `vitest` to `check-coverage`.
* [`.github/workflows/check-javascript-format.yaml`](diffhunk://#diff-93d175f62fe05ee52a7ee5783156537a2e57bfa0be9eac114a43326490d3cce4L15-R15): Renamed job from `prettier` to `check-format`.
* [`.github/workflows/check-javascript-lint.yaml`](diffhunk://#diff-4ada1a4c455a0547aabc56c94c3fa5b1ab9be6f2aa28400c46dec43d1adf0f41L15-R15): Renamed job from `eslint` to `check-lint`.
* [`.github/workflows/check-javascript-tests.yaml`](diffhunk://#diff-d5a90c3061051676636d088c742a245c793dbefbb947d1c9cec49b572025a05bL15-R15): Renamed job from `vitest` to `check-tests`.

Changes to Vite configuration:

* [`frontend/vite.config.ts`](diffhunk://#diff-97c6e2c429ec483132c584137a18a1ade2ff6c3f4f6485f4a83db604d0323d7cL21-L26): Removed coverage thresholds for lines, functions, branches, and statements.