### PR TITLE
feat: add React context for auth to frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,21 +2,14 @@
 
 import "./App.css";
 import { BrowserRouter, Routes, Route } from "react-router";
-import {
-  useAuthState,
-  useSignInWithGoogle,
-  useSignOut,
-} from "react-firebase-hooks/auth";
-import {
-  auth,
-  initializeAnalytics,
-  getFirebaseAnalytics,
-} from "@/lib/firebase";
+import { initializeAnalytics, getFirebaseAnalytics } from "@/lib/firebase";
+import { AuthProvider } from "@/contexts/authProvider";
 import { logEvent } from "firebase/analytics";
 import { User } from "firebase/auth";
 import GoogleButton from "react-google-button";
 import { LDProvider, useFlags } from "launchdarkly-react-client-sdk";
-import { useEffect } from "react";
+import { useContext, useEffect } from "react";
+import { AuthContext } from "@/contexts/authContext.ts";
 
 const LD_CLIENT_ID = import.meta.env.PROD
   ? `67f0bff500b7a80955249fc7`
@@ -32,10 +25,12 @@ export function App() {
     <>
       <BrowserRouter>
         <LDProvider clientSideID={LD_CLIENT_ID}>
-          <Routes>
-            <Route path="/" element={<IndexPage />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
+          <AuthProvider>
+            <Routes>
+              <Route path="/" element={<IndexPage />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </AuthProvider>
         </LDProvider>
       </BrowserRouter>
     </>
@@ -43,12 +38,13 @@ export function App() {
 }
 
 function IndexPage() {
-  const [firebaseUser, authStateLoading, authError] = useAuthState(auth);
+  const { firebaseUser, isAuthStateLoading, authError } =
+    useContext(AuthContext);
 
   return (
     <AuthDisplay
       firebaseUser={firebaseUser}
-      authStateLoading={authStateLoading}
+      authStateLoading={isAuthStateLoading}
       authError={authError}
     />
   );
@@ -65,8 +61,7 @@ export function AuthDisplay({
   authStateLoading,
   authError,
 }: AuthDisplayProps) {
-  const [signInWithGoogle] = useSignInWithGoogle(auth);
-  const [signOut] = useSignOut(auth);
+  const { signInWithGoogle, signOut } = useContext(AuthContext);
   const { killSwitchEnableGoogleSignIn } = useFlags();
 
   const handleGoogleButtonClick = () => {

--- a/frontend/src/contexts/authContext.ts
+++ b/frontend/src/contexts/authContext.ts
@@ -1,0 +1,16 @@
+// frontend/src/contexts/authContext.ts
+
+import { createContext } from "react";
+import { User, UserCredential } from "firebase/auth";
+
+export interface AuthContextType {
+  firebaseUser: User | null | undefined;
+  isAuthStateLoading: boolean;
+  authError: Error | undefined;
+  signInWithGoogle: () => Promise<UserCredential | undefined>;
+  signOut: () => Promise<boolean>;
+}
+
+export const AuthContext = createContext<AuthContextType>(
+  {} as AuthContextType,
+);

--- a/frontend/src/contexts/authProvider.test.tsx
+++ b/frontend/src/contexts/authProvider.test.tsx
@@ -1,0 +1,158 @@
+// frontend/src/contexts/authProvider.test.tsx
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { AuthProvider } from "./authProvider";
+import { AuthContext } from "./authContext";
+import { useContext } from "react";
+import { User } from "firebase/auth";
+
+// Mock the firebase hooks module
+vi.mock("react-firebase-hooks/auth", () => ({
+  useAuthState: vi.fn(),
+  useSignInWithGoogle: vi.fn(),
+  useSignOut: vi.fn(),
+}));
+
+// Mock firebase.ts
+vi.mock("@/lib/firebase.ts", () => ({
+  auth: {},
+}));
+
+// Import mocked modules
+import {
+  useAuthState,
+  useSignInWithGoogle,
+  useSignOut,
+} from "react-firebase-hooks/auth";
+
+// Test component to consume the context
+const TestComponent = () => {
+  const auth = useContext(AuthContext);
+
+  return (
+    <div>
+      <div data-testid="user-state">
+        {auth.firebaseUser ? "signed-in" : "signed-out"}
+      </div>
+      <div data-testid="loading-state">{String(auth.isAuthStateLoading)}</div>
+      <div data-testid="error-state">
+        {auth.authError ? "error" : "no-error"}
+      </div>
+      <button
+        type="button"
+        data-testid="sign-in"
+        onClick={() => {
+          void auth.signInWithGoogle();
+        }}
+      >
+        Sign In
+      </button>
+      <button
+        type="button"
+        data-testid="sign-out"
+        onClick={() => {
+          void auth.signOut();
+        }}
+      >
+        Sign Out
+      </button>
+    </div>
+  );
+};
+
+/**
+ * AuthProvider tests
+ */
+describe("AuthProvider", () => {
+  const mockSignIn = vi.fn().mockResolvedValue({ user: { uid: "123" } });
+  const mockSignOut = vi.fn().mockResolvedValue(true);
+
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+
+    vi.mocked(useAuthState).mockReturnValue([null, false, undefined]);
+    // useSignInWithGoogle returns [signInFunction, user, loading, error]
+    vi.mocked(useSignInWithGoogle).mockReturnValue([
+      mockSignIn,
+      undefined,
+      false,
+      undefined,
+    ]);
+    // useSignOut returns [signOutFunction, loading, error]
+    vi.mocked(useSignOut).mockReturnValue([mockSignOut, false, undefined]);
+  });
+
+  it("should provide auth context with initial values", () => {
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId("user-state").textContent).toBe("signed-out");
+    expect(screen.getByTestId("loading-state").textContent).toBe("false");
+    expect(screen.getByTestId("error-state").textContent).toBe("no-error");
+  });
+
+  it("should reflect authenticated state when user exists", () => {
+    const mockUser = { uid: "123", displayName: "Test User" } as User;
+    vi.mocked(useAuthState).mockReturnValue([mockUser, false, undefined]);
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId("user-state").textContent).toBe("signed-in");
+  });
+
+  it("should reflect loading state", () => {
+    vi.mocked(useAuthState).mockReturnValue([null, true, undefined]);
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId("loading-state").textContent).toBe("true");
+  });
+
+  it("should reflect error state", () => {
+    const error = new Error("Auth error");
+    vi.mocked(useAuthState).mockReturnValue([null, false, error]);
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId("error-state").textContent).toBe("error");
+  });
+
+  it("should call sign in method when triggered", () => {
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    screen.getByTestId("sign-in").click();
+    expect(mockSignIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call sign out method when triggered", () => {
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    screen.getByTestId("sign-out").click();
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/contexts/authProvider.tsx
+++ b/frontend/src/contexts/authProvider.tsx
@@ -1,0 +1,37 @@
+// frontend/src/contexts/authProvider.tsx
+
+import * as React from "react";
+import { useMemo } from "react";
+import {
+  useAuthState,
+  useSignInWithGoogle,
+  useSignOut,
+} from "react-firebase-hooks/auth";
+
+import { auth } from "@/lib/firebase.ts";
+import { AuthContext } from "@/contexts/authContext";
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [firebaseUser, isAuthStateLoading, authError] = useAuthState(auth);
+  const [signInWithGoogle] = useSignInWithGoogle(auth);
+  const [signOut] = useSignOut(auth);
+
+  const contextValue = useMemo(
+    () => ({
+      firebaseUser,
+      isAuthStateLoading,
+      authError,
+      signInWithGoogle,
+      signOut,
+    }),
+    [firebaseUser, isAuthStateLoading, authError, signInWithGoogle, signOut],
+  );
+
+  return (
+    <>
+      <AuthContext.Provider value={contextValue}>
+        {children}
+      </AuthContext.Provider>
+    </>
+  );
+};


### PR DESCRIPTION
This pull request refactors the authentication logic in the frontend by introducing a new context-based approach for managing authentication state and actions. It replaces the direct use of Firebase hooks with a centralized `AuthContext` and `AuthProvider`, simplifying state management and improving testability. Additionally, comprehensive unit tests for the new provider have been added.

### Refactoring Authentication Logic:

* **Introduction of `AuthContext` and `AuthProvider`:**
  - Added `AuthContext` in `frontend/src/contexts/authContext.ts` to define the structure for authentication-related state and actions.
  - Implemented `AuthProvider` in `frontend/src/contexts/authProvider.tsx` to encapsulate Firebase hooks and expose authentication state (`firebaseUser`, `isAuthStateLoading`, `authError`) and actions (`signInWithGoogle`, `signOut`) via context.

* **Integration of `AuthProvider` in the application:**
  - Wrapped the app's `Routes` component with `AuthProvider` in `frontend/src/App.tsx` to ensure authentication context is available throughout the app.
  - Replaced direct usage of Firebase hooks with `useContext(AuthContext)` in components like `IndexPage` and `AuthDisplay`, streamlining the access to authentication state and actions. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL5-R12) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL68-R64)

### Testing Enhancements:

* **Unit tests for `AuthProvider`:**
  - Added `frontend/src/contexts/authProvider.test.tsx` to thoroughly test the behavior of `AuthProvider`, including initial state, authenticated state, loading state, error state, and the invocation of `signInWithGoogle` and `signOut` methods.

These changes improve the modularity and maintainability of the authentication logic while ensuring robust test coverage for the new implementation.