### PR TITLE
feat: add support for toast message component and context

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@eslint/js": "^9.21.0",
         "@testing-library/dom": "^10.4.0",
+        "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@types/jsdom": "^21.1.7",
         "@types/react": "^19.0.10",
@@ -48,6 +49,13 @@
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.17",
         "lightningcss-linux-x64-gnu": "^1.29.3"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.2.tgz",
+      "integrity": "sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -2173,6 +2181,48 @@
         "node": ">=18"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/react": {
       "version": "16.2.0",
       "dev": true,
@@ -2938,6 +2988,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssstyle": {
       "version": "4.3.0",
@@ -3932,6 +3989,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -4483,6 +4550,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "license": "MIT"
@@ -4615,6 +4689,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -5019,6 +5103,20 @@
         }
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "dev": true,
@@ -5323,6 +5421,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@types/jsdom": "^21.1.7",
     "@types/react": "^19.0.10",

--- a/frontend/src/components/Toast.test.tsx
+++ b/frontend/src/components/Toast.test.tsx
@@ -11,8 +11,8 @@ const renderWithToastContext = (toasts: ToastType[]) => {
     <ToastContext.Provider
       value={{
         toasts,
-        addToast: () => {},
-        removeToast: () => {},
+        addToast: () => vi.fn(),
+        removeToast: () => vi.fn(),
       }}
     >
       <Toast />
@@ -20,11 +20,15 @@ const renderWithToastContext = (toasts: ToastType[]) => {
   );
 };
 
-describe("Toast component", () => {
+/**
+ * Toast tests
+ */
+describe("Toast", () => {
   beforeEach(() => {
     cleanup();
     vi.resetAllMocks();
   });
+
   it("should render nothing when there are no toasts", () => {
     const { container } = renderWithToastContext([]);
     expect(container.innerHTML).toBe("");

--- a/frontend/src/components/Toast.test.tsx
+++ b/frontend/src/components/Toast.test.tsx
@@ -1,0 +1,102 @@
+// frontend/src/components/Toast.test.tsx
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Toast } from "./Toast";
+import { ToastContext, Toast as ToastType } from "@/contexts/toastContext";
+
+// Helper function to create a wrapper with mocked context
+const renderWithToastContext = (toasts: ToastType[]) => {
+  return render(
+    <ToastContext.Provider
+      value={{
+        toasts,
+        addToast: () => {},
+        removeToast: () => {},
+      }}
+    >
+      <Toast />
+    </ToastContext.Provider>,
+  );
+};
+
+describe("Toast component", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+  it("should render nothing when there are no toasts", () => {
+    const { container } = renderWithToastContext([]);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("should render a success toast with the correct class name", () => {
+    renderWithToastContext([
+      { id: 1, type: "success", message: "Success message" },
+    ]);
+
+    const alertElement = screen.getByRole("alert");
+    expect(alertElement).toHaveClass("alert");
+    expect(alertElement).toHaveClass("alert-success");
+    expect(screen.getByText("Success message")).toBeInTheDocument();
+  });
+
+  it("should render an error toast with the correct class name", () => {
+    renderWithToastContext([
+      { id: 2, type: "error", message: "Error message" },
+    ]);
+
+    const alertElement = screen.getByRole("alert");
+    expect(alertElement).toHaveClass("alert");
+    expect(alertElement).toHaveClass("alert-error");
+    expect(screen.getByText("Error message")).toBeInTheDocument();
+  });
+
+  it("should render a warning toast with the correct class name", () => {
+    renderWithToastContext([
+      { id: 3, type: "warning", message: "Warning message" },
+    ]);
+
+    const alertElement = screen.getByRole("alert");
+    expect(alertElement).toHaveClass("alert");
+    expect(alertElement).toHaveClass("alert-warning");
+    expect(screen.getByText("Warning message")).toBeInTheDocument();
+  });
+
+  it("should render an info toast with the correct class name", () => {
+    renderWithToastContext([{ id: 4, type: "info", message: "Info message" }]);
+
+    const alertElement = screen.getByRole("alert");
+    expect(alertElement).toHaveClass("alert");
+    expect(alertElement).toHaveClass("alert-info");
+    expect(screen.getByText("Info message")).toBeInTheDocument();
+  });
+
+  it("should render multiple toasts when provided", () => {
+    const { container } = renderWithToastContext([
+      { id: 5, type: "success", message: "First toast" },
+      { id: 6, type: "error", message: "Second toast" },
+      { id: 7, type: "warning", message: "Third toast" },
+    ]);
+
+    const alertElements = container.querySelectorAll('[role="alert"]');
+    expect(alertElements).toHaveLength(3);
+
+    expect(alertElements[0]).toHaveClass("alert-success");
+    expect(alertElements[1]).toHaveClass("alert-error");
+    expect(alertElements[2]).toHaveClass("alert-warning");
+
+    expect(screen.getByText("First toast")).toBeInTheDocument();
+    expect(screen.getByText("Second toast")).toBeInTheDocument();
+    expect(screen.getByText("Third toast")).toBeInTheDocument();
+  });
+
+  it("should render each toast with the toast class", () => {
+    renderWithToastContext([
+      { id: 8, type: "success", message: "Toast message" },
+    ]);
+
+    const toastElement = screen.getByText("Toast message").closest(".toast");
+    expect(toastElement).toHaveClass("toast");
+  });
+});

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -15,11 +15,15 @@ export function Toast() {
 
   if (!toasts.length) return null;
 
-  return toasts.map((toast) => (
-    <div className="toast" key={toast.id}>
-      <div role="alert" className={`alert ${toastClasses[toast.type]}`}>
-        <span>{toast.message}</span>
-      </div>
-    </div>
-  ));
+  return (
+    <>
+      {toasts.map((toast) => (
+        <div className="toast" key={toast.id}>
+          <div role="alert" className={`alert ${toastClasses[toast.type]}`}>
+            <span>{toast.message}</span>
+          </div>
+        </div>
+      ))}
+    </>
+  );
 }

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,25 @@
+// frontend/src/components/Toast.tsx
+
+import { useContext } from "react";
+import { ToastContext } from "@/contexts/toastContext.ts";
+
+export function Toast() {
+  const { toasts } = useContext(ToastContext);
+
+  const toastClasses = {
+    success: "alert-success",
+    error: "alert-error",
+    warning: "alert-warning",
+    info: "alert-info",
+  };
+
+  if (!toasts.length) return null;
+
+  return toasts.map((toast) => (
+    <div className="toast" key={toast.id}>
+      <div role="alert" className={`alert ${toastClasses[toast.type]}`}>
+        <span>{toast.message}</span>
+      </div>
+    </div>
+  ));
+}

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,7 +1,7 @@
 // frontend/src/components/Toast.tsx
 
 import { useContext } from "react";
-import { ToastContext } from "@/contexts/toastContext.ts";
+import { ToastContext } from "@/contexts/toastContext";
 
 export function Toast() {
   const { toasts } = useContext(ToastContext);

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,3 +1,3 @@
 // frontend/src/constants.ts
 
-export const DEFAULT_TOAST_DURATION = 5000;
+export const DEFAULT_TOAST_DURATION = 5;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,0 +1,3 @@
+// frontend/src/constants.ts
+
+export const DEFAULT_TOAST_DURATION = 5000;

--- a/frontend/src/contexts/toastContext.ts
+++ b/frontend/src/contexts/toastContext.ts
@@ -1,0 +1,37 @@
+// frontend/src/contexts/toastContext.ts
+
+import { createContext } from "react";
+
+export type ToastType = "success" | "error" | "warning" | "info";
+
+export interface Toast {
+  id: number;
+  type: ToastType;
+  message: string;
+  expirationInSeconds?: number | null;
+}
+
+export interface ToastContextType {
+  toasts: Toast[];
+  addToast: (
+    type: ToastType,
+    message: string,
+    expirationInSeconds?: number,
+  ) => void;
+  removeToast: (id: number) => void;
+}
+
+const defaultToasts: Toast[] = [];
+
+const defaultToastContext: ToastContextType = {
+  toasts: defaultToasts,
+  addToast: () => {
+    return;
+  },
+  removeToast: () => {
+    return;
+  },
+};
+
+export const ToastContext =
+  createContext<ToastContextType>(defaultToastContext);

--- a/frontend/src/contexts/toastContext.ts
+++ b/frontend/src/contexts/toastContext.ts
@@ -8,16 +8,12 @@ export interface Toast {
   id: number;
   type: ToastType;
   message: string;
-  expirationInSeconds?: number | null;
+  duration?: number | null;
 }
 
 export interface ToastContextType {
   toasts: Toast[];
-  addToast: (
-    type: ToastType,
-    message: string,
-    expirationInSeconds?: number,
-  ) => void;
+  addToast: (type: ToastType, message: string, duration?: number) => void;
   removeToast: (id: number) => void;
 }
 

--- a/frontend/src/contexts/toastProvider.test.tsx
+++ b/frontend/src/contexts/toastProvider.test.tsx
@@ -12,7 +12,7 @@ import {
 
 import { ToastProvider } from "./toastProvider";
 import { ToastContext } from "./toastContext";
-import { DEFAULT_TOAST_EXPIRATION_IN_SECONDS } from "@/constants";
+import { DEFAULT_TOAST_DURATION } from "@/constants";
 
 // Mock setTimeout and clearTimeout
 vi.useFakeTimers();
@@ -146,7 +146,7 @@ describe("ToastProvider", () => {
     expect(screen.getByTestId("toasts-count").textContent).toBe("0");
   });
 
-  it("should automatically remove a toast after the default expiration time", () => {
+  it("should automatically remove a toast after the default duration time", () => {
     render(
       <ToastProvider>
         <TestComponent />
@@ -156,9 +156,9 @@ describe("ToastProvider", () => {
     fireEvent.click(screen.getByTestId("add-success-toast"));
     expect(screen.getByTestId("toasts-count").textContent).toBe("1");
 
-    // Fast-forward time by the default expiration time
+    // Fast-forward time by the default duration time
     act(() => {
-      vi.advanceTimersByTime(DEFAULT_TOAST_EXPIRATION_IN_SECONDS * 1000);
+      vi.advanceTimersByTime(DEFAULT_TOAST_DURATION * 1000);
     });
 
     expect(screen.getByTestId("toasts-count").textContent).toBe("0");
@@ -174,9 +174,9 @@ describe("ToastProvider", () => {
     fireEvent.click(screen.getByTestId("add-persistent-toast"));
     expect(screen.getByTestId("toasts-count").textContent).toBe("1");
 
-    // Fast-forward time by more than the default expiration time
+    // Fast-forward time by more than the default duration time
     act(() => {
-      vi.advanceTimersByTime(DEFAULT_TOAST_EXPIRATION_IN_SECONDS * 2000);
+      vi.advanceTimersByTime(DEFAULT_TOAST_DURATION * 2000);
     });
 
     // The toast should still be there

--- a/frontend/src/contexts/toastProvider.test.tsx
+++ b/frontend/src/contexts/toastProvider.test.tsx
@@ -1,0 +1,185 @@
+// frontend/src/contexts/toastProvider.test.tsx
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useContext } from "react";
+import {
+  cleanup,
+  render,
+  screen,
+  act,
+  fireEvent,
+} from "@testing-library/react";
+
+import { ToastProvider } from "./toastProvider";
+import { ToastContext } from "./toastContext";
+import { DEFAULT_TOAST_EXPIRATION_IN_SECONDS } from "@/constants";
+
+// Mock setTimeout and clearTimeout
+vi.useFakeTimers();
+
+// Test component to consume the context
+const TestComponent = () => {
+  const { toasts, addToast, removeToast } = useContext(ToastContext);
+
+  return (
+    <div>
+      <div data-testid="toasts-count">{toasts.length}</div>
+
+      <div data-testid="toasts-list">
+        {toasts.map((toast) => (
+          <div key={toast.id} data-testid={`toast-${toast.id.toString()}`}>
+            {toast.type}: {toast.message}
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        data-testid="add-success-toast"
+        onClick={() => {
+          addToast("success", "Success message");
+        }}
+      >
+        Add Success Toast
+      </button>
+
+      <button
+        type="button"
+        data-testid="add-error-toast"
+        onClick={() => {
+          addToast("error", "Error message");
+        }}
+      >
+        Add Error Toast
+      </button>
+
+      <button
+        type="button"
+        data-testid="add-persistent-toast"
+        onClick={() => {
+          addToast("info", "Persistent message", -1);
+        }}
+      >
+        Add Persistent Toast
+      </button>
+
+      <button
+        type="button"
+        data-testid="remove-toast"
+        onClick={() => {
+          if (toasts.length > 0) {
+            removeToast(toasts[0].id);
+          }
+        }}
+      >
+        Remove First Toast
+      </button>
+    </div>
+  );
+};
+
+/**
+ * ToastProvider tests
+ */
+describe("ToastProvider", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    vi.clearAllTimers();
+  });
+
+  it("should provide toast context with initial empty toasts array", () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    expect(screen.getByTestId("toasts-count").textContent).toBe("0");
+  });
+
+  it("should add a toast when addToast is called", () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("add-success-toast"));
+
+    expect(screen.getByTestId("toasts-count").textContent).toBe("1");
+    expect(screen.getByTestId("toasts-list").textContent).toContain(
+      "success: Success message",
+    );
+  });
+
+  it("should add multiple toasts when addToast is called multiple times", () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("add-success-toast"));
+    fireEvent.click(screen.getByTestId("add-error-toast"));
+
+    expect(screen.getByTestId("toasts-count").textContent).toBe("2");
+    expect(screen.getByTestId("toasts-list").textContent).toContain(
+      "success: Success message",
+    );
+    expect(screen.getByTestId("toasts-list").textContent).toContain(
+      "error: Error message",
+    );
+  });
+
+  it("should remove a toast when removeToast is called", () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("add-success-toast"));
+    expect(screen.getByTestId("toasts-count").textContent).toBe("1");
+
+    fireEvent.click(screen.getByTestId("remove-toast"));
+    expect(screen.getByTestId("toasts-count").textContent).toBe("0");
+  });
+
+  it("should automatically remove a toast after the default expiration time", () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("add-success-toast"));
+    expect(screen.getByTestId("toasts-count").textContent).toBe("1");
+
+    // Fast-forward time by the default expiration time
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_TOAST_EXPIRATION_IN_SECONDS * 1000);
+    });
+
+    expect(screen.getByTestId("toasts-count").textContent).toBe("0");
+  });
+
+  it("should not automatically remove a persistent toast", () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("add-persistent-toast"));
+    expect(screen.getByTestId("toasts-count").textContent).toBe("1");
+
+    // Fast-forward time by more than the default expiration time
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_TOAST_EXPIRATION_IN_SECONDS * 2000);
+    });
+
+    // The toast should still be there
+    expect(screen.getByTestId("toasts-count").textContent).toBe("1");
+  });
+});

--- a/frontend/src/contexts/toastProvider.tsx
+++ b/frontend/src/contexts/toastProvider.tsx
@@ -1,0 +1,44 @@
+// frontend/src/contexts/toastProvider.tsx
+
+import * as React from "react";
+import { useCallback, useMemo, useState } from "react";
+
+import { DEFAULT_TOAST_EXPIRATION_IN_SECONDS } from "@/constants";
+import { ToastContext, Toast, ToastType } from "@/contexts/toastContext";
+
+export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const removeToast = useCallback((id: number) => {
+    setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id));
+  }, []);
+
+  const addToast = useCallback(
+    (
+      type: ToastType,
+      message: string,
+      expirationInSeconds = DEFAULT_TOAST_EXPIRATION_IN_SECONDS,
+    ) => {
+      const id = Date.now();
+      setToasts((prevToasts) => [...prevToasts, { id, type, message }]);
+
+      if (expirationInSeconds) {
+        return setTimeout(() => {
+          removeToast(id);
+        }, expirationInSeconds * 1000);
+      }
+    },
+    [removeToast],
+  );
+
+  const contextValue = useMemo(
+    () => ({ toasts, addToast, removeToast }),
+    [toasts, addToast, removeToast],
+  );
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      {children}
+    </ToastContext.Provider>
+  );
+};

--- a/frontend/src/contexts/toastProvider.tsx
+++ b/frontend/src/contexts/toastProvider.tsx
@@ -9,20 +9,34 @@ import { ToastContext, Toast, ToastType } from "@/contexts/toastContext";
 export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
+  /**
+   * Removes a toast message from the list of toasts in the context.
+   * @param id - The unique identifier of the toast to remove, based on timestamp and random number.
+   */
   const removeToast = useCallback((id: number) => {
     setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id));
   }, []);
 
+  /**
+   * Adds a new toast message to the list of toasts in the context.
+   * @param type - The type of the toast (success, error, warning, info).
+   * @param message - The message to display in the toast.
+   * @param expirationInSeconds - The duration in seconds after which the toast should disappear.
+   *                              For persistent toasts, pass a negative number.
+   */
   const addToast = useCallback(
     (
       type: ToastType,
       message: string,
       expirationInSeconds = DEFAULT_TOAST_EXPIRATION_IN_SECONDS,
     ) => {
-      const id = Date.now();
-      setToasts((prevToasts) => [...prevToasts, { id, type, message }]);
+      const id = Date.now() + Math.random(); // Unique ID based on timestamp and random number
+      setToasts((prevToasts) => [
+        ...prevToasts,
+        { id, type, message, expirationInSeconds },
+      ]);
 
-      if (expirationInSeconds) {
+      if (expirationInSeconds > 0) {
         return setTimeout(() => {
           removeToast(id);
         }, expirationInSeconds * 1000);

--- a/frontend/src/contexts/toastProvider.tsx
+++ b/frontend/src/contexts/toastProvider.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { useCallback, useMemo, useState } from "react";
 
-import { DEFAULT_TOAST_EXPIRATION_IN_SECONDS } from "@/constants";
+import { DEFAULT_TOAST_DURATION } from "@/constants";
 import { ToastContext, Toast, ToastType } from "@/contexts/toastContext";
 
 export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
@@ -21,25 +21,21 @@ export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
    * Adds a new toast message to the list of toasts in the context.
    * @param type - The type of the toast (success, error, warning, info).
    * @param message - The message to display in the toast.
-   * @param expirationInSeconds - The duration in seconds after which the toast should disappear.
-   *                              For persistent toasts, pass a negative number.
+   * @param duration - The duration in seconds after which the toast should disappear.
+   *                   For persistent toasts, pass a negative number.
    */
   const addToast = useCallback(
-    (
-      type: ToastType,
-      message: string,
-      expirationInSeconds = DEFAULT_TOAST_EXPIRATION_IN_SECONDS,
-    ) => {
+    (type: ToastType, message: string, duration = DEFAULT_TOAST_DURATION) => {
       const id = Date.now() + Math.random(); // Unique ID based on timestamp and random number
       setToasts((prevToasts) => [
         ...prevToasts,
-        { id, type, message, expirationInSeconds },
+        { id, type, message, duration: duration },
       ]);
 
-      if (expirationInSeconds > 0) {
+      if (duration > 0) {
         return setTimeout(() => {
           removeToast(id);
-        }, expirationInSeconds * 1000);
+        }, duration * 1000);
       }
     },
     [removeToast],

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,3 @@
+// frontend/src/setupTests.ts
+
+import "@testing-library/jest-dom/vitest";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
+    setupFiles: ["./src/setupTests.ts"],
     coverage: {
       provider: "istanbul",
     },


### PR DESCRIPTION
This pull request introduces a toast notification system for the frontend, including a `Toast` component, context, provider, and comprehensive tests. The changes enable the display of success, error, warning, and info notifications, with support for automatic or manual dismissal.

### Toast Notification System Implementation:

* **`Toast` Component**:
  - Added `Toast` component to render toast notifications based on the context-provided list of toasts. Each toast is styled according to its type (`success`, `error`, `warning`, `info`) and supports dynamic rendering. (`frontend/src/components/Toast.tsx`)

* **Toast Context**:
  - Created `ToastContext` to manage the state and behavior of toast notifications, including methods for adding and removing toasts. (`frontend/src/contexts/toastContext.ts`)

* **Toast Provider**:
  - Implemented `ToastProvider` to wrap the application and provide the `ToastContext` to its children. It handles toast addition, removal, and expiration logic, including persistent toasts. (`frontend/src/contexts/toastProvider.tsx`)

### Testing:

* **Component Tests**:
  - Added tests for the `Toast` component to verify correct rendering of different toast types, multiple toasts, and appropriate class names. (`frontend/src/components/Toast.test.tsx`)

* **Provider Tests**:
  - Added tests for the `ToastProvider` to ensure proper context behavior, including adding, removing, and automatically expiring toasts. Persistent toasts are also tested. (`frontend/src/contexts/toastProvider.test.tsx`)