### PR TITLE
feat: add tailwind variants and remove default styling for various elements

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,4 @@
 #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,65 +1,37 @@
 /* frontend/src/index.css */
 
 @import "tailwindcss";
+
 @plugin "daisyui";
+
+/* Light mode variant */
+@custom-variant light {
+  @media (prefers-color-scheme: light) {
+    /*noinspection CssInvalidAtRule*/
+    @slot;
+  }
+}
+
+/* Device that supports hover */
+@custom-variant can-hover {
+  @media (hover: hover) {
+    /* supress the following inspection rule until JetBrains CSS plugin is fixed */
+    /*noinspection CssInvalidAtRule*/
+    @slot;
+  }
+}
 
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-
-button:hover {
-  border-color: #646cff;
-}
-
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
 @media (prefers-color-scheme: light) {
@@ -67,12 +39,10 @@ button:focus-visible {
     color: #213547;
     background-color: #ffffff;
   }
+}
 
-  a:hover {
-    color: #747bff;
-  }
-
-  button {
-    background-color: #f9f9f9;
-  }
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
 }


### PR DESCRIPTION
This pull request introduces changes to improve the styling structure of the frontend by removing redundant styles, adding custom variants for better responsiveness, and simplifying the CSS codebase. The key changes are grouped into two themes: **CSS Cleanup** and **Custom Styling Enhancements**.

### CSS Cleanup:
* Removed redundant styles from `frontend/src/App.css`, such as `padding` and `text-align` properties for the `#root` element.
* Simplified and cleaned up `frontend/src/index.css` by removing unused global styles for elements like `a`, `h1`, and `button`, as well as redundant light mode-specific styles.

### Custom Styling Enhancements:
* Introduced `@custom-variant` definitions in `frontend/src/index.css` for `light` and `can-hover` variants, enabling better support for light mode and hover-capable devices.