### PR TITLE
deps: install lucide react icon library and update react-router

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.0.14",
         "firebase": "^11.5.0",
         "launchdarkly-react-client-sdk": "^3.6.1",
+        "lucide-react": "^0.488.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-firebase-hooks": "^5.1.1",
@@ -4593,6 +4594,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.488.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.488.0.tgz",
+      "integrity": "sha512-ronlL0MyKut4CEzBY/ai2ZpKPxyWO4jUqdAkm2GNK5Zn3Rj+swDz+3lvyAUXN0PNqPKIX6XM9Xadwz/skLs/pQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "dev": true,
@@ -5081,9 +5091,9 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.1.tgz",
-      "integrity": "sha512-/jjU3fcYNd2bwz9Q0xt5TwyiyoO8XjSEFXJY4O/lMAlkGTHWuHRAbR9Etik+lSDqMC7A7mz3UlXzgYT6Vl58sA==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.3.tgz",
+      "integrity": "sha512-3iUDM4/fZCQ89SXlDa+Ph3MevBrozBAI655OAfWQlTm9nBR0IKlrmNwFow5lPHttbwvITZfkeeeZFP6zt3F7pw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@tailwindcss/vite": "^4.0.14",
     "firebase": "^11.5.0",
     "launchdarkly-react-client-sdk": "^3.6.1",
+    "lucide-react": "^0.488.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-firebase-hooks": "^5.1.1",


### PR DESCRIPTION
This pull request updates dependencies in the `frontend` project, including adding a new package and upgrading an existing one. The most significant changes involve the addition of `lucide-react` and the update of `react-router` to a newer version.

### Dependency Updates:

* Added `lucide-react` package (`^0.488.0`) to both `frontend/package.json` and `frontend/package-lock.json`. This includes its metadata, resolved URL, integrity hash, and peer dependencies. [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR14) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR4597-R4605) [[3]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R20)

* Upgraded `react-router` from version `7.5.1` to `7.5.3` in `frontend/package-lock.json`, updating its resolved URL and integrity hash.