### PR TITLE
feat: add tracking for CRUD actions

### DIFF
--- a/frontend/src/components/UserDisplay.test.tsx
+++ b/frontend/src/components/UserDisplay.test.tsx
@@ -27,18 +27,18 @@ vi.mock("firebase/analytics", () => ({
 // Mock Firebase lib
 vi.mock("@/lib/firebase", () => ({
   getFirebaseAnalytics: vi.fn().mockReturnValue({}),
-  trackLoginEvent: vi.fn(),
+  trackEvent: vi.fn(),
 }));
 
 // Import mocked libraries after mocking them
 import { useFlags } from "launchdarkly-react-client-sdk";
-import { getFirebaseAnalytics, trackLoginEvent } from "@/lib/firebase";
+import { getFirebaseAnalytics, trackEvent } from "@/lib/firebase";
 
 /**
  * UserDisplay tests
  */
 describe("UserDisplay", () => {
-  const mockedTrackLoginEvent = trackLoginEvent as Mock;
+  const mockedTrackEvent = trackEvent as Mock;
 
   beforeEach(() => {
     cleanup();
@@ -152,9 +152,9 @@ describe("UserDisplay", () => {
     // Verify that signInWithGoogle was called
     expect(mockSignInWithGoogle).toHaveBeenCalled();
 
-    // Verify that trackLoginEvent was called
+    // Verify that trackEvent was called
     await vi.waitFor(() => {
-      expect(mockedTrackLoginEvent).toHaveBeenCalled();
+      expect(mockedTrackEvent).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components/UserDisplay.tsx
+++ b/frontend/src/components/UserDisplay.tsx
@@ -22,7 +22,7 @@ export function UserDisplay() {
   const handleGoogleButtonClick = useCallback(() => {
     async function performSignIn() {
       const user = await signInWithGoogle();
-      if (user) await trackEvent("login", { method: "Google" });
+      if (user) void trackEvent("login", { method: "Google" });
       return;
     }
 

--- a/frontend/src/components/UserDisplay.tsx
+++ b/frontend/src/components/UserDisplay.tsx
@@ -5,7 +5,7 @@ import { useFlags } from "launchdarkly-react-client-sdk";
 import GoogleButton from "react-google-button";
 
 import { AuthContext } from "@/contexts/authContext.ts";
-import { trackLoginEvent } from "@/lib/firebase.ts";
+import { trackEvent } from "@/lib/firebase.ts";
 
 export const SIGN_OUT_BUTTON_TEXT = "Sign Out";
 
@@ -22,7 +22,7 @@ export function UserDisplay() {
   const handleGoogleButtonClick = useCallback(() => {
     async function performSignIn() {
       const user = await signInWithGoogle();
-      if (user) await trackLoginEvent();
+      if (user) await trackEvent("login", { method: "Google" });
       return;
     }
 

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -9,6 +9,7 @@ import {
   Analytics,
   isSupported as isAnalyticsSupported,
   logEvent,
+  EventParams,
 } from "firebase/analytics";
 import { getAuth } from "firebase/auth";
 
@@ -50,11 +51,13 @@ export async function getFirebaseAnalytics(): Promise<Analytics | undefined> {
 }
 
 /**
- * Tracks the login event in Firebase Analytics.
+ * Tracks a custom event in Firebase Analytics.
+ * @param eventName The name of the event to track.
+ * @param eventParams Optional parameters associated with the event.
  */
-export async function trackLoginEvent() {
+export async function trackEvent(eventName: string, eventParams?: EventParams) {
   const analytics = await getFirebaseAnalytics();
   if (!analytics) return;
-  logEvent(analytics, "login", { method: "Google" });
+  logEvent(analytics, eventName, eventParams);
   return;
 }

--- a/frontend/src/pages/TripEditPage.tsx
+++ b/frontend/src/pages/TripEditPage.tsx
@@ -13,6 +13,7 @@ import {
 import { ToastContext } from "@/contexts/toastContext";
 import { AuthContext } from "@/contexts/authContext";
 import { convertFormDataToStringSafely } from "@/utils/utils";
+import { trackEvent } from "@/lib/firebase.ts";
 
 export const TRIP_EDIT_PAGE_FORM_NAME = "edit-trip-form";
 export const TRIP_EDIT_PAGE_FORM_ACCESSIBLE_NAME = "Edit Trip Form";
@@ -87,6 +88,7 @@ export function EditTripForm({ tripId }: EditTripFormProps) {
         const response = await updateTrip(token, tripId, updatedTrip);
         if (response.data) {
           addToast("success", "Trip updated successfully.");
+          void trackEvent("update_trip");
           void navigate(`/trips/${tripId.toString()}`);
         } else if (response.error) {
           console.error("Error updating trip: ", response.error.message);

--- a/frontend/src/pages/TripListPage.tsx
+++ b/frontend/src/pages/TripListPage.tsx
@@ -19,6 +19,7 @@ import {
   getTrips,
   Trip,
 } from "@/utils/tripService.ts";
+import { trackEvent } from "@/lib/firebase.ts";
 
 export const TRIP_LIST_PAGE_HEADER = "My Trips";
 export const TRIP_LIST_PAGE_ADD_TRIP_BUTTON_TEXT = "Add Trip";
@@ -103,6 +104,7 @@ function TripList({ userTrips, setUserTrips }: TripListProps) {
           });
 
           addToast("success", "Trip deleted successfully.");
+          void trackEvent("delete_trip", { source: "list_page" });
         } else {
           console.error("Error deleting trip: ", response.error.message);
           addToast("error", response.error.message);

--- a/frontend/src/pages/TripNewPage.tsx
+++ b/frontend/src/pages/TripNewPage.tsx
@@ -8,6 +8,7 @@ import { BaseTrip, createTrip } from "@/utils/tripService.ts";
 import { ToastContext } from "@/contexts/toastContext.ts";
 import { convertFormDataToStringSafely } from "@/utils/utils.ts";
 import { AuthContext } from "@/contexts/authContext.ts";
+import { trackEvent } from "@/lib/firebase.ts";
 
 export const TRIP_NEW_PAGE_HEADER = "New Trip";
 export const TRIP_NEW_PAGE_FORM_NAME = "new-trip-form";
@@ -47,6 +48,7 @@ function AddTripForm() {
         const response = await createTrip(token, newTrip);
         if (response.data) {
           addToast("success", "Trip added successfully.");
+          void trackEvent("add_trip");
           void navigate(`/trips/${response.data.id.toString()}`);
         }
         (event.target as HTMLFormElement).reset();

--- a/frontend/src/pages/TripShowPage.tsx
+++ b/frontend/src/pages/TripShowPage.tsx
@@ -12,6 +12,7 @@ import {
 import { ToastContext } from "@/contexts/toastContext.ts";
 import { BackButton } from "@/components/BackButton.tsx";
 import { AuthContext } from "@/contexts/authContext.ts";
+import { trackEvent } from "@/lib/firebase.ts";
 
 export function TripShowPage() {
   const { addToast } = useContext(ToastContext);
@@ -82,6 +83,7 @@ function TripDetailsHeader({ trip }: TripDetailsHeaderProps) {
 
       if (!response.error) {
         addToast("success", "Trip deleted successfully.");
+        void trackEvent("delete_trip", { source: "show_page" });
         await navigate("/trips");
       } else {
         console.error("Error deleting trip: ", response.error.message);


### PR DESCRIPTION
This pull request refactors the analytics tracking system by replacing the `trackLoginEvent` function with a more generic `trackEvent` function and updating its usage across the codebase. Additionally, it introduces event tracking for various user actions such as creating, updating, and deleting trips.

### Refactoring and Generalization of Event Tracking:
* [`frontend/src/lib/firebase.ts`](diffhunk://#diff-172d9ce26f34738a93aa25cd0170a3ec5d96a54357cdb857a92f5590c2d4e4afL53-R61): Replaced the `trackLoginEvent` function with a more generic `trackEvent` function that accepts an event name and optional parameters. Updated its implementation to use these parameters when logging events.

### Updates to Existing Event Tracking:
* [`frontend/src/components/UserDisplay.tsx`](diffhunk://#diff-0e25b92dace19915f892631bcc9920d179c9f037ffb50c1c619096c3fb2c1b5cL25-R25): Updated the `handleGoogleButtonClick` function to use the new `trackEvent` function for logging login events with additional metadata.

### New Event Tracking for Trip Actions:
* [`frontend/src/pages/TripEditPage.tsx`](diffhunk://#diff-756b051df30681a340264aa89bd0074eabe28d8328b1efec079a35cea6483989R91): Added a `trackEvent` call to log "update_trip" events when a trip is successfully updated.
* [`frontend/src/pages/TripNewPage.tsx`](diffhunk://#diff-a8a8206dcf42c6c990157ab8b129342eac8aa328316bc352ec0291c7ccc3780aR51): Added a `trackEvent` call to log "add_trip" events when a new trip is successfully created.
* `frontend/src/pages/TripListPage.tsx` and `frontend/src/pages/TripShowPage.tsx`: Added `trackEvent` calls to log "delete_trip" events with contextual metadata for trip deletions from both the list and show pages. [[1]](diffhunk://#diff-191b17785580eada0b2d8a7cd768d98caf6c1fb66e8a2a982651d3f91cd3fef9R107) [[2]](diffhunk://#diff-b0f1399384caeb821b93e3f4a0ba8947177d221ce52943caf2e50e921d8dbff4R86)