### PR TITLE
refactor: rename mock auth data for consistency

### DIFF
--- a/frontend/src/components/UserDisplay.test.tsx
+++ b/frontend/src/components/UserDisplay.test.tsx
@@ -8,9 +8,9 @@ import {
   mockUser,
   mockAnalytics,
   mockSignInWithGoogle,
-  authContextLoading,
   mockAuthContextLoggedOut,
   mockAuthContextLoggedIn,
+  mockAuthContextLoading,
 } from "@/test-utils";
 import { AuthContext } from "@/contexts/authContext";
 import { getFirebaseAnalytics, trackEvent } from "@/lib/firebase";
@@ -56,7 +56,7 @@ describe("UserDisplay", () => {
 
   it("should render nothing when auth state is loading", () => {
     const { container } = render(
-      <AuthContext.Provider value={authContextLoading}>
+      <AuthContext.Provider value={mockAuthContextLoading}>
         <UserDisplay />
       </AuthContext.Provider>,
     );

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -24,7 +24,7 @@ import {
   LOGIN_PAGE_SIGN_IN_DISABLED_TEXT,
 } from "@/pages/LoginPage";
 import {
-  authContextLoading,
+  mockAuthContextLoading,
   mockAuthContextLoggedIn,
   mockAuthContextLoggedOut,
   mockSignInWithGoogle,
@@ -76,7 +76,7 @@ describe("<LoginPage />", () => {
   it("renders loading state when auth state is loading", () => {
     render(
       <BrowserRouter>
-        <AuthContext.Provider value={authContextLoading}>
+        <AuthContext.Provider value={mockAuthContextLoading}>
           <LoginPage />
         </AuthContext.Provider>
       </BrowserRouter>,

--- a/frontend/src/test-utils.tsx
+++ b/frontend/src/test-utils.tsx
@@ -60,7 +60,7 @@ export const mockUser = {
 
 export const mockFirebaseToken = "test-firebase-token";
 
-export const authContextLoading: AuthContextType = {
+export const mockAuthContextLoading: AuthContextType = {
   firebaseUser: null,
   isAuthStateLoading: true,
   authError: undefined,


### PR DESCRIPTION
This pull request refactors test utilities and updates test files to improve consistency in naming and usage of mock authentication contexts. The most important changes include renaming `authContextLoading` to `mockAuthContextLoading` and updating all references to use the new name.

### Refactoring of test utilities:
* Renamed `authContextLoading` to `mockAuthContextLoading` in `frontend/src/test-utils.tsx` to align with the naming convention of other mock objects.

### Updates to test files:
* Updated imports in `frontend/src/components/UserDisplay.test.tsx` and `frontend/src/pages/LoginPage.test.tsx` to replace `authContextLoading` with `mockAuthContextLoading`. [[1]](diffhunk://#diff-9ee2814611894ddc94d9848427911163bba5622448732ca2f84a0ad3be39245bL11-R13) [[2]](diffhunk://#diff-c2d2703def3e8f57d3c274c4defcc4362ac37d8719c5e6c0f931b3efffdab459L27-R27)
* Replaced instances of `authContextLoading` with `mockAuthContextLoading` in test cases for `UserDisplay` and `LoginPage` components to ensure the tests use the updated mock object. [[1]](diffhunk://#diff-9ee2814611894ddc94d9848427911163bba5622448732ca2f84a0ad3be39245bL59-R59) [[2]](diffhunk://#diff-c2d2703def3e8f57d3c274c4defcc4362ac37d8719c5e6c0f931b3efffdab459L79-R79)