### PR TITLE
feat: render loading screen on index page

### DIFF
--- a/frontend/src/pages/IndexPage.test.tsx
+++ b/frontend/src/pages/IndexPage.test.tsx
@@ -11,6 +11,7 @@ import { IndexPage, SIGN_IN_TEXT } from "@/pages/IndexPage";
 import { TripListPage, PAGE_HEADER } from "@/pages/TripListPage";
 import {
   mockAuthContextLoggedIn,
+  mockAuthContextLoading,
   mockAuthContextLoggedOut,
   mockGetIdToken,
   mockToastContextValue,
@@ -27,7 +28,6 @@ describe("<IndexPage />", () => {
     vi.mocked(mockGetIdToken).mockResolvedValue("fake-token");
   });
 
-  // authContextLoggedIn.firebaseUser.getIdToken.mockResolvedValue("fake-token");
   it("renders the sign in button when logged out", () => {
     render(
       <AuthContext.Provider value={mockAuthContextLoggedOut}>
@@ -59,11 +59,36 @@ describe("<IndexPage />", () => {
       </AuthContext.Provider>,
     );
 
-    // Wait for the redirect and TripListPage to render
+    // Verify the TripListPage is displayed
     await waitFor(() => {
       expect(screen.getByText(PAGE_HEADER)).toBeInTheDocument();
     });
 
+    // Verify that IndexPage is no longer displayed
     expect(screen.queryByText(SIGN_IN_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("should render loading screen when auth state is loading", () => {
+    render(
+      <AuthContext.Provider value={mockAuthContextLoading}>
+        <BrowserRouter>
+          <IndexPage />
+        </BrowserRouter>
+      </AuthContext.Provider>,
+    );
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
+  it("should render loading screen when user is logged in while waiting for redirect to Trips List Page", () => {
+    render(
+      <AuthContext.Provider value={mockAuthContextLoggedIn}>
+        <BrowserRouter>
+          <IndexPage />
+        </BrowserRouter>
+      </AuthContext.Provider>,
+    );
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/IndexPage.tsx
+++ b/frontend/src/pages/IndexPage.tsx
@@ -5,11 +5,12 @@ import { Link, useNavigate } from "react-router";
 import { LogIn } from "lucide-react";
 
 import { AuthContext } from "@/contexts/authContext";
+import { LoadingScreen } from "@/components/LoadingScreen";
 
 export const SIGN_IN_TEXT = "Sign in";
 
 export function IndexPage() {
-  const { firebaseUser } = useContext(AuthContext);
+  const { firebaseUser, isAuthStateLoading } = useContext(AuthContext);
   const navigate = useNavigate();
 
   // Redirect to /trips if the user is authenticated
@@ -19,8 +20,8 @@ export function IndexPage() {
     }
   }, [firebaseUser, navigate]);
 
-  if (firebaseUser) {
-    return null;
+  if (isAuthStateLoading || firebaseUser) {
+    return <LoadingScreen />;
   }
 
   return (


### PR DESCRIPTION
This pull request enhances the `IndexPage` component and its tests by adding support for an intermediate loading state during authentication. The changes ensure that the UI behaves correctly when the authentication state is loading or when a logged-in user is being redirected.

### Enhancements to `IndexPage` Component:

* Added `isAuthStateLoading` to the `AuthContext` usage in `IndexPage` to handle the loading state. If the authentication state is loading or the user is logged in, the `LoadingScreen` component is displayed. (`frontend/src/pages/IndexPage.tsx`, [[1]](diffhunk://#diff-e7187c83ff4447d651660ce3a079c1f7a525c1b63750522af98be8acf2b33778R8-R13) [[2]](diffhunk://#diff-e7187c83ff4447d651660ce3a079c1f7a525c1b63750522af98be8acf2b33778L22-R24)

### Improvements to `IndexPage` Tests:

* Introduced `mockAuthContextLoading` to simulate the loading state in tests. (`frontend/src/pages/IndexPage.test.tsx`, [frontend/src/pages/IndexPage.test.tsxR14](diffhunk://#diff-8b307fb165914222499d2b387d8f752cb9ed81b1e0ac78a041245a01d4757fb2R14))
* Added a new test case to verify that the `LoadingScreen` is rendered when the authentication state is loading. (`frontend/src/pages/IndexPage.test.tsx`, [frontend/src/pages/IndexPage.test.tsxL62-R93](diffhunk://#diff-8b307fb165914222499d2b387d8f752cb9ed81b1e0ac78a041245a01d4757fb2L62-R93))
* Added a test case to ensure the `LoadingScreen` is displayed for logged-in users while waiting for redirection to the `TripListPage`. (`frontend/src/pages/IndexPage.test.tsx`, [frontend/src/pages/IndexPage.test.tsxL62-R93](diffhunk://#diff-8b307fb165914222499d2b387d8f752cb9ed81b1e0ac78a041245a01d4757fb2L62-R93))
* Clarified comments in existing tests for better readability and understanding. (`frontend/src/pages/IndexPage.test.tsx`, [[1]](diffhunk://#diff-8b307fb165914222499d2b387d8f752cb9ed81b1e0ac78a041245a01d4757fb2L30) [[2]](diffhunk://#diff-8b307fb165914222499d2b387d8f752cb9ed81b1e0ac78a041245a01d4757fb2L62-R93)